### PR TITLE
🛡️ Sentinel: Harden site-wide security headers and third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Use of insecure `http://` for API endpoints in build scripts and potential for data-driven links to point to insecure URLs, exposing users to man-in-the-middle (MITM) attacks.
 **Learning:** While most hardcoded links may be secure, external data and build scripts are often overlooked and can introduce insecure transport paths. A global `upgrade-insecure-requests` CSP provides an effective safety net.
 **Prevention:** Always use `https://` for API endpoints and external links. Implement `upgrade-insecure-requests` Content-Security-Policy to automatically upgrade any remaining insecure requests in the browser.
+
+## 2026-03-09 - Hardening Site-Wide Headers and Third-Party Embeds
+**Vulnerability:** Lack of restricted sandboxing for third-party iframes and missing/ineffective Referrer Policy, potentially exposing user privacy or allowing unauthorized iframe actions.
+**Learning:** Standardizing security headers in the global layout ensures defense-in-depth across all pages. Specifically, the Referrer Policy meta tag must use the exact name `referrer` to be recognized by browsers. Sandboxing iframes with specific flags allows content to function while preventing it from escaping the sandbox or performing unintended top-level navigations.
+**Prevention:** Implement `object-src 'none'` and `base-uri 'self'` in CSP globally. Always use `<meta name="referrer" ...>` for Referrer Policy. Harden all third-party embeds with `sandbox` attributes using the minimum required permissions.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Security Enhancement: Automatically upgrade all insecure (HTTP) requests to secure (HTTPS) -->
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+    <!-- Content-Security-Policy includes upgrade-insecure-requests, object-src 'none' to prevent plugin-based attacks, and base-uri 'self' to restrict <base> tag. -->
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests; object-src 'none'; base-uri 'self'">
+
+    <!-- Referrer Policy: strict-origin-when-cross-origin protects user privacy and prevents leaking sensitive information in Referer headers. -->
+    <meta name="referrer" content="strict-origin-when-cross-origin">
 
     <meta http-equiv='Expires' content='0'>
     <meta http-equiv='Pragma' content='no-cache'>

--- a/publicity.html
+++ b/publicity.html
@@ -31,7 +31,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <p class="center-text mega-margin">
-            <iframe width=320 height=180 src="https://www.youtube.com/embed/v8IVMdOBs_0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe width=320 height=180 src="https://www.youtube.com/embed/v8IVMdOBs_0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             Episode of <i>Disease Hunters</i> on CNA, focused on bacteria and antibiotic resistance.<br>
             [ <a href="https://m.youtube.com/watch?feature=youtu.be&v=v8IVMdOBs_0">Trailer</a> ] [ <a href="https://www.channelnewsasia.com/news/video-on-demand/disease-hunters/disease-hunters-battle-against-bacteria-13622094">Full Episode</a> ] (2020)
@@ -64,7 +64,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <p class="center-text mega-margin">
-            <iframe width=320 height=180 src="https://www.youtube.com/embed/fDAHUow34_Q" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe width=320 height=180 src="https://www.youtube.com/embed/fDAHUow34_Q" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://www.asianscientist.com/2019/05/features/sea-beast-gbs-food-safety-aquaculture/">Op-Ed/Perspective</a> in <a href="https://www.asianscientist.com">Asian Scientist</a> on our GBS work throughout SEAsia, including <a href="https://youtu.be/fDAHUow34_Q">video</a>
           </p>
@@ -80,7 +80,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <p class="center-text mega-margin">
-            <iframe width=320 height=180 src="https://www.youtube.com/embed/yIJB8Deo-XU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe width=320 height=180 src="https://www.youtube.com/embed/yIJB8Deo-XU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://youtu.be/yIJB8Deo-XU">TEDx talk</a> - A genomic future is upon us (2018)
           </p>
@@ -88,7 +88,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <p class="center-text mega-margin">
-            <iframe width=320 height=180 src="https://www.youtube.com/embed/AmHCUy-_VPI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe width=320 height=180 src="https://www.youtube.com/embed/AmHCUy-_VPI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://www.seriouslyscience.sg/Knowledge/Videos/Genomics-Helping-to-Tackle-Infections-and-Beyond-in-a-Smart-Nation">Public talk</a> at the One North Festival (2018)
           </p>
@@ -96,7 +96,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <p class="center-text mega-margin">
-            <iframe width=320 height=180 src="https://www.youtube.com/embed/d5dOlbArKh0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe width=320 height=180 src="https://www.youtube.com/embed/d5dOlbArKh0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://youtu.be/d5dOlbArKh0">Keynote</a> at the AWS Public Sector Summit (2018)
           </p>
@@ -104,7 +104,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <p class="center-text mega-margin">
-            <iframe width=320 height=180 src="https://www.youtube.com/embed/pK8JcT3F0jU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe width=320 height=180 src="https://www.youtube.com/embed/pK8JcT3F0jU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://youtu.be/pK8JcT3F0jU">Interview</a> with SiliconEdge<br>on the sidelines of the AWS Public Sector Summit (2018)
           </p>
@@ -120,7 +120,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <p class="center-text mega-margin">
-            <iframe width=320 height=180 src="https://www.youtube.com/embed/yEtx0Aknke8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe width=320 height=180 src="https://www.youtube.com/embed/yEtx0Aknke8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             CNA <a href="https://youtu.be/yEtx0Aknke8">video</a> and <a href="https://www.channelnewsasia.com/news/cnainsider/how-dirty-money-bacteria-banknotes-singapore-9503352">article</a> on bacteria on bank notes (2017)</a>
           </p>
@@ -128,7 +128,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <p class="center-text mega-margin">
-            <iframe frameborder="0" width=320 height=180 allowfullscreen src="https://www.mewatch.sg/en/embed/556200"  allow="autoplay;fullscreen;encrypted-media" ></iframe>
+            <iframe frameborder="0" width=320 height=180 allowfullscreen src="https://www.mewatch.sg/en/embed/556200"  allow="autoplay;fullscreen;encrypted-media" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://www.mewatch.sg/en/series/talking-point-2017/ep34/556200">Talking Point with Steven Chia</a> about bacteria on shopping carts in Singapore (2017)
           </p>


### PR DESCRIPTION
This PR implements several security enhancements to harden the Chen Lab website against common vulnerabilities and improve user privacy.

### 🛡️ Security Enhancements

1. **Iframe Sandboxing**: Added the `sandbox` attribute to all eight third-party iframes in `publicity.html` (YouTube and meWatch). The flags `allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox` were used to provide security isolation while maintaining the functionality required for video players.

2. **CSP Hardening**: Updated the site-wide `Content-Security-Policy` in `_layouts/default.html` to include:
    - `object-src 'none'`: Prevents the execution of potentially malicious plugins (e.g., Flash).
    - `base-uri 'self'`: Restricts the allowed values for the `<base>` tag, preventing base tag hijacking.

3. **Referrer Policy**: Implemented a global Referrer Policy via `<meta name="referrer" content="strict-origin-when-cross-origin">` in `_layouts/default.html`. This protects user privacy by stripping the path and query string when navigating from HTTPS to a different origin.

### ✅ Verification Results

- **Automated Tests**: A Playwright script (`verify_security.py`) was used to verify the rendered HTML in the `_site` directory. It confirmed:
    - All 8 iframes have the correct `sandbox` attribute.
    - The CSP meta tag contains the new directives.
    - The Referrer Policy is correctly implemented using the standard `name="referrer"`.
- **Build**: `npm run build:css` and `bundle exec jekyll build` both passed successfully.

### 📓 Sentinel Journal
Documented these findings and the specific learning regarding the Referrer Policy meta tag name in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9002197259873929555](https://jules.google.com/task/9002197259873929555) started by @swainechen*