### PR TITLE
🛡️ Sentinel: Harden HTML integrity and site-wide structure

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,7 @@
     <!-- Security Enhancement: Automatically upgrade all insecure (HTTP) requests to secure (HTTPS) -->
     <!-- Content-Security-Policy includes upgrade-insecure-requests, object-src 'none' to prevent plugin-based attacks, and base-uri 'none' to restrict <base> tag. -->
     <!-- img-src 'self' data: https: restricts image sources to trusted origins and enforces secure transport. -->
+    <!-- connect-src 'self' restricts the URLs which can be loaded using script interfaces. -->
     <!-- form-action 'none' prevents unauthorized form submissions as the site contains no forms. -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests; object-src 'none'; base-uri 'none'; form-action 'none'; img-src 'self' data: https:; script-src 'self' https://platform.twitter.com; style-src 'self' 'unsafe-inline'; frame-src https://www.youtube.com https://www.mewatch.sg https://platform.twitter.com;">
 
@@ -143,10 +144,9 @@
 
         </div>
     </div> <!-- End of Footer -->
+    <script src="{{ site.baseurl }}/js/main.js"></script>
+    <script src="{{ site.baseurl }}/js/responsive.js"></script>
+    <script src="{{ site.baseurl }}/js/{{ page.custom_js }}"></script>
   </body>
 
 </html>
-
-<script src="{{ site.baseurl }}/js/main.js"></script>
-<script src="{{ site.baseurl }}/js/responsive.js"></script>
-<script src="{{ site.baseurl }}/js/{{ page.custom_js }}"></script>

--- a/css/main.css
+++ b/css/main.css
@@ -233,8 +233,12 @@ body {
 	line-height: var(--feather-line-height-large);
 }
 
-.center-text {
+.center-text, .center-align {
 	text-align: center;
+}
+
+.fixed-height {
+	height: 180px;
 }
 
 .small-title {

--- a/publicity.html
+++ b/publicity.html
@@ -30,132 +30,132 @@ custom_js: publicity.js
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
+          <div class="center-text mega-margin">
             <iframe width="320" height="180" src="https://www.youtube.com/embed/v8IVMdOBs_0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             Episode of <i>Disease Hunters</i> on CNA, focused on bacteria and antibiotic resistance.<br>
             [ <a href="https://m.youtube.com/watch?feature=youtu.be&v=v8IVMdOBs_0" target="_blank" rel="noopener noreferrer">Trailer</a> ] [ <a href="https://www.channelnewsasia.com/news/video-on-demand/disease-hunters/disease-hunters-battle-against-bacteria-13622094" target="_blank" rel="noopener noreferrer">Full Episode</a> ] (2020)
-          </p>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
-            <div height="180" align="center"><a href="https://www.straitstimes.com/singapore/health/genetic-scissors-from-bacteria-a-tool-to-slice-and-dice-code-of-life" target="_blank" rel="noopener noreferrer"><img src="https://www.straitstimes.com/assets/ST-logo-default-aoeSLh4S.png" width="320"></a></div>
+          <div class="center-text mega-margin">
+            <div class="fixed-height center-align"><a href="https://www.straitstimes.com/singapore/health/genetic-scissors-from-bacteria-a-tool-to-slice-and-dice-code-of-life" target="_blank" rel="noopener noreferrer"><img src="https://www.straitstimes.com/assets/ST-logo-default-aoeSLh4S.png" width="320"></a></div>
           <br>
-            <center><a href="https://www.straitstimes.com/singapore/health/genetic-scissors-from-bacteria-a-tool-to-slice-and-dice-code-of-life" target="_blank" rel="noopener noreferrer">Perspective on CRISPR and bacterial research</a> after the 2020 Nobel Prize in Chemistry was announced. The Straits Times (2020)</center>
-          </p>
+            <div class="center-align"><a href="https://www.straitstimes.com/singapore/health/genetic-scissors-from-bacteria-a-tool-to-slice-and-dice-code-of-life" target="_blank" rel="noopener noreferrer">Perspective on CRISPR and bacterial research</a> after the 2020 Nobel Prize in Chemistry was announced. The Straits Times (2020)</div>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
-            <div height="180" align="center"><a href="https://www.scotsman.com/news/opinion/columnists/covid-19-pandemic-shows-how-all-humanity-same-boat-chong-yap-seng-and-swaine-chen-2864049" target="_blank" rel="noopener noreferrer"><img src="https://www.scotsman.com/img/logo.png" width="320"></a></div>
+          <div class="center-text mega-margin">
+            <div class="fixed-height center-align"><a href="https://www.scotsman.com/news/opinion/columnists/covid-19-pandemic-shows-how-all-humanity-same-boat-chong-yap-seng-and-swaine-chen-2864049" target="_blank" rel="noopener noreferrer"><img src="https://www.scotsman.com/img/logo.png" width="320"></a></div>
           <br>
-            <center><a href="https://www.scotsman.com/news/opinion/columnists/covid-19-pandemic-shows-how-all-humanity-same-boat-chong-yap-seng-and-swaine-chen-2864049" target="_blank" rel="noopener noreferrer">Op-Ed on the importance of pandemic preparedness</a> in The Scotsman (2020)</center>
-          </p>
+            <div class="center-align"><a href="https://www.scotsman.com/news/opinion/columnists/covid-19-pandemic-shows-how-all-humanity-same-boat-chong-yap-seng-and-swaine-chen-2864049" target="_blank" rel="noopener noreferrer">Op-Ed on the importance of pandemic preparedness</a> in The Scotsman (2020)</div>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
-            <div height="180" align="center"><a href="https://www.thenationalnews.com/opinion/get-ready-there-will-be-another-pandemic-1.1024060" target="_blank" rel="noopener noreferrer"><img src="assets/national-logo.png" width="320"></a></div>
+          <div class="center-text mega-margin">
+            <div class="fixed-height center-align"><a href="https://www.thenationalnews.com/opinion/get-ready-there-will-be-another-pandemic-1.1024060" target="_blank" rel="noopener noreferrer"><img src="assets/national-logo.png" width="320"></a></div>
           <br>
-            <center><a href="https://www.thenationalnews.com/opinion/get-ready-there-will-be-another-pandemic-1.1024060" target="_blank" rel="noopener noreferrer">Op-Ed on the inevitibilty of more outbreaks</a> in The National (UAE) (2020)</center>
-          </p>
+            <div class="center-align"><a href="https://www.thenationalnews.com/opinion/get-ready-there-will-be-another-pandemic-1.1024060" target="_blank" rel="noopener noreferrer">Op-Ed on the inevitibilty of more outbreaks</a> in The National (UAE) (2020)</div>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
+          <div class="center-text mega-margin">
             <iframe width="320" height="180" src="https://www.youtube.com/embed/fDAHUow34_Q" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://www.asianscientist.com/2019/05/features/sea-beast-gbs-food-safety-aquaculture/" target="_blank" rel="noopener noreferrer">Op-Ed/Perspective</a> in <a href="https://www.asianscientist.com" target="_blank" rel="noopener noreferrer">Asian Scientist</a> on our GBS work throughout SEAsia, including <a href="https://youtu.be/fDAHUow34_Q" target="_blank" rel="noopener noreferrer">video</a>
-          </p>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
+          <div class="center-text mega-margin">
             <a href="https://www.channelnewsasia.com/news/singapore/gbs-bacteria-t283-singapore-2015-raw-fish-blood-poisoning-11708534" target="_blank" rel="noopener noreferrer"><img src="https://www.channelnewsasia.com/blueprint/cna/img/logo-cna-new.svg" height="100"></a>
           <br>
-            <center><a href="https://www.channelnewsasia.com/news/singapore/gbs-bacteria-t283-singapore-2015-raw-fish-blood-poisoning-11708534" target="_blank" rel="noopener noreferrer">CNA Coverage</a> of the <a href="https://journals.plos.org/plosntds/article?id=10.1371/journal.pntd.0007421" target="_blank" rel="noopener noreferrer">Barkham, et al. PlosNTD paper</a> (2019)</center>
-          </p>
+            <div class="center-align"><a href="https://www.channelnewsasia.com/news/singapore/gbs-bacteria-t283-singapore-2015-raw-fish-blood-poisoning-11708534" target="_blank" rel="noopener noreferrer">CNA Coverage</a> of the <a href="https://journals.plos.org/plosntds/article?id=10.1371/journal.pntd.0007421" target="_blank" rel="noopener noreferrer">Barkham, et al. PlosNTD paper</a> (2019)</div>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
+          <div class="center-text mega-margin">
             <iframe width="320" height="180" src="https://www.youtube.com/embed/yIJB8Deo-XU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://youtu.be/yIJB8Deo-XU" target="_blank" rel="noopener noreferrer">TEDx talk</a> - A genomic future is upon us (2018)
-          </p>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
+          <div class="center-text mega-margin">
             <iframe width="320" height="180" src="https://www.youtube.com/embed/AmHCUy-_VPI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://www.seriouslyscience.sg/Knowledge/Videos/Genomics-Helping-to-Tackle-Infections-and-Beyond-in-a-Smart-Nation" target="_blank" rel="noopener noreferrer">Public talk</a> at the One North Festival (2018)
-          </p>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
+          <div class="center-text mega-margin">
             <iframe width="320" height="180" src="https://www.youtube.com/embed/d5dOlbArKh0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://youtu.be/d5dOlbArKh0" target="_blank" rel="noopener noreferrer">Keynote</a> at the AWS Public Sector Summit (2018)
-          </p>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
+          <div class="center-text mega-margin">
             <iframe width="320" height="180" src="https://www.youtube.com/embed/pK8JcT3F0jU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://youtu.be/pK8JcT3F0jU" target="_blank" rel="noopener noreferrer">Interview</a> with SiliconEdge<br>on the sidelines of the AWS Public Sector Summit (2018)
-          </p>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
-            <div height="180" align="center"><a href="https://www.straitstimes.com/singapore/genomics-for-the-smart-nation" target="_blank" rel="noopener noreferrer"><img src="https://www.straitstimes.com/assets/ST-logo-default-aoeSLh4S.png" width="320"></a></div>
+          <div class="center-text mega-margin">
+            <div class="fixed-height center-align"><a href="https://www.straitstimes.com/singapore/genomics-for-the-smart-nation" target="_blank" rel="noopener noreferrer"><img src="https://www.straitstimes.com/assets/ST-logo-default-aoeSLh4S.png" width="320"></a></div>
           <br>
-            <center><a href="https://www.straitstimes.com/singapore/genomics-for-the-smart-nation" target="_blank" rel="noopener noreferrer">Op-Ed about genomics</a> in the Straits Times (2017)</center>
-          </p>
+            <div class="center-align"><a href="https://www.straitstimes.com/singapore/genomics-for-the-smart-nation" target="_blank" rel="noopener noreferrer">Op-Ed about genomics</a> in the Straits Times (2017)</div>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
+          <div class="center-text mega-margin">
             <iframe width="320" height="180" src="https://www.youtube.com/embed/yEtx0Aknke8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             CNA <a href="https://youtu.be/yEtx0Aknke8" target="_blank" rel="noopener noreferrer">video</a> and <a href="https://www.channelnewsasia.com/news/cnainsider/how-dirty-money-bacteria-banknotes-singapore-9503352" target="_blank" rel="noopener noreferrer">article</a> on bacteria on bank notes (2017)
-          </p>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
+          <div class="center-text mega-margin">
             <iframe frameborder="0" width="320" height="180" allowfullscreen src="https://www.mewatch.sg/en/embed/556200"  allow="autoplay;fullscreen;encrypted-media" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>
           <br>
             <a href="https://www.mewatch.sg/en/series/talking-point-2017/ep34/556200" target="_blank" rel="noopener noreferrer">Talking Point with Steven Chia</a> about bacteria on shopping carts in Singapore (2017)
-          </p>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
-            <div height="180" align="center"><a href="https://www.asianscientist.com/2017/08/features/asias-rising-scientists-swaine-chen/" target="_blank" rel="noopener noreferrer"><img src="https://www.asianscientist.com/wp-content/uploads/2017/08/logo_asian_scientist.png" width="320"></a></div>
+          <div class="center-text mega-margin">
+            <div class="fixed-height center-align"><a href="https://www.asianscientist.com/2017/08/features/asias-rising-scientists-swaine-chen/" target="_blank" rel="noopener noreferrer"><img src="https://www.asianscientist.com/wp-content/uploads/2017/08/logo_asian_scientist.png" width="320"></a></div>
           <br>
-            <center><a href="https://www.asianscientist.com/2017/08/features/asias-rising-scientists-swaine-chen/" target="_blank" rel="noopener noreferrer">Profile</a> in Asian Scientist (2017)</center>
-          </p>
+            <div class="center-align"><a href="https://www.asianscientist.com/2017/08/features/asias-rising-scientists-swaine-chen/" target="_blank" rel="noopener noreferrer">Profile</a> in Asian Scientist (2017)</div>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
-            <div height="180" align="center"><a href="https://www.opengovasia.com/exclusive-deciphering-data-from-the-blueprint-of-life-a-conversation-with-dr-swaine-chen/" target="_blank" rel="noopener noreferrer"><img src="https://www.opengovasia.com/wp-content/uploads/2018/11/OpenGov-header-logo-1.jpg" height="135"></a></div>
+          <div class="center-text mega-margin">
+            <div class="fixed-height center-align"><a href="https://www.opengovasia.com/exclusive-deciphering-data-from-the-blueprint-of-life-a-conversation-with-dr-swaine-chen/" target="_blank" rel="noopener noreferrer"><img src="https://www.opengovasia.com/wp-content/uploads/2018/11/OpenGov-header-logo-1.jpg" height="135"></a></div>
           <br>
-            <center><a href="https://www.opengovasia.com/exclusive-deciphering-data-from-the-blueprint-of-life-a-conversation-with-dr-swaine-chen/" target="_blank" rel="noopener noreferrer">Interview</a> in OpenGov Asia (2017)</center>
-          </p>
+            <div class="center-align"><a href="https://www.opengovasia.com/exclusive-deciphering-data-from-the-blueprint-of-life-a-conversation-with-dr-swaine-chen/" target="_blank" rel="noopener noreferrer">Interview</a> in OpenGov Asia (2017)</div>
+          </div>
         </div>
 
         <div class="Grid-cell img-card u-size1of3">
-          <p class="center-text mega-margin">
-            <div height="180" align="center" class="virulence-header"><a href="https://www.tandfonline.com/doi/full/10.1080/21505594.2017.1317998" target="_blank" rel="noopener noreferrer">Virulence<br><br><img src="https://www.tandfonline.com/pb-assets/Global/tfo_logo-1444989687640.png" width="320"></a></div>
+          <div class="center-text mega-margin">
+            <div class="fixed-height center-align virulence-header"><a href="https://www.tandfonline.com/doi/full/10.1080/21505594.2017.1317998" target="_blank" rel="noopener noreferrer">Virulence<br><br><img src="https://www.tandfonline.com/pb-assets/Global/tfo_logo-1444989687640.png" width="320"></a></div>
           <br>
-            <center><a href="https://www.tandfonline.com/doi/full/10.1080/21505594.2017.1317998" target="_blank" rel="noopener noreferrer">Personal profile</a> in the journal Virulence (2017)</center>
-          </p>
+            <div class="center-align"><a href="https://www.tandfonline.com/doi/full/10.1080/21505594.2017.1317998" target="_blank" rel="noopener noreferrer">Personal profile</a> in the journal Virulence (2017)</div>
+          </div>
         </div>
 
     </div>


### PR DESCRIPTION
I have hardened the HTML integrity and site-wide structure of the Chen Lab website. 

Key changes include:
1.  **Validating HTML Structure:** Relocated `<script>` tags in `_layouts/default.html` to before the closing `</body>` tag, ensuring compliance with HTML5 standards and predictable script execution.
2.  **Fixing Invalid Nesting:** Refactored `publicity.html` to replace invalid nesting of `<div>` and `<iframe>` elements inside `<p>` tags with semantic `<div>` containers.
3.  **Modernizing Layout:** Removed deprecated `<center>` tags and `align="center"` attributes in `publicity.html`, replacing them with modern CSS classes (`.center-align` and `.fixed-height`) added to `css/main.css`.
4.  **Verification:** Confirmed the changes by building the site with Jekyll and performing frontend verification using Playwright to ensure no regressions in layout or functionality.

---
*PR created automatically by Jules for task [5421067600202903907](https://jules.google.com/task/5421067600202903907) started by @swainechen*