### PR TITLE
🛡️ Sentinel: Fix Resource Exhaustion in Build Scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,8 @@
 **Vulnerability:** Third-party scripts (Twitter widgets) missing `crossorigin` attribute and malformed HTML (nested empty `<p>` tags) which could lead to credential leaking and unpredictable DOM parsing.
 **Learning:** Even well-known third-party scripts should be fetched securely using `crossorigin="anonymous"` to protect user privacy. Furthermore, inconsistent HTML patterns like `<p><p>` increase the risk of parsing-related vulnerabilities and should be refactored into semantic structures.
 **Prevention:** Always include `crossorigin="anonymous"` for third-party script tags. Maintain strict HTML validity by using proper paragraph blocks and avoiding invalid tag sequences to ensure a robust defense-in-depth posture.
+
+## 2026-03-28 - Mitigation of Resource Exhaustion in Build Pipeline
+**Vulnerability:** External API requests in Python build scripts were missing timeouts, potentially allowing the build process to hang indefinitely if a service became unresponsive.
+**Learning:** Default behavior for the `requests` library in Python is to wait indefinitely for a response, which can block CI/CD pipelines and consume resources.
+**Prevention:** Always specify a `timeout` parameter for all network requests in automation and build scripts to ensure they fail gracefully and don't stall the pipeline.

--- a/scripts/fetch_augur_metrics.py
+++ b/scripts/fetch_augur_metrics.py
@@ -99,7 +99,8 @@ for repo in PROJECTS_TRACKED['projects']['twitter']:
 
   # hits endpoint using specific repo_ids
   print(f"Sending request to {API_ENDPOINT}/repo-groups/twitter/repos/{repo_id}/code-changes")
-  r = requests.get(f"{API_ENDPOINT}/repo-groups/twitter/repos/{repo_id}/code-changes")
+  # Security Enhancement: Added timeout to prevent the build from hanging indefinitely
+  r = requests.get(f"{API_ENDPOINT}/repo-groups/twitter/repos/{repo_id}/code-changes", timeout=10)
   try:
     if r.ok:
       print("OK!")

--- a/scripts/fetch_projects.py
+++ b/scripts/fetch_projects.py
@@ -22,7 +22,8 @@ def fetch_one_page(query_string, variables):
     headers = {
         "Content-Type": "application/json",
     }
-    r = requests.post(GITHUB_API_ENDPOINT, json={"query": query_string, "variables": variables}, auth=(GITHUB_USERNAME, GITHUB_OAUTH_TOKEN))
+    # Security Enhancement: Added timeout to prevent the build from hanging indefinitely
+    r = requests.post(GITHUB_API_ENDPOINT, json={"query": query_string, "variables": variables}, auth=(GITHUB_USERNAME, GITHUB_OAUTH_TOKEN), timeout=30)
     if r.status_code == 200:
         return r.json()
     else:

--- a/scripts/fetch_year_in_review.py
+++ b/scripts/fetch_year_in_review.py
@@ -32,7 +32,8 @@ if os.path.exists(aggregate_summary_json_file):
 
 # the repo_group_id for Twitter org is 25155
 print(f"Sending request to {API_ENDPOINT}/repo-groups/25155/aggregate-summary")
-r = requests.get(f"{API_ENDPOINT}/repo-groups/25155/aggregate-summary")
+# Security Enhancement: Added timeout to prevent the build from hanging indefinitely
+r = requests.get(f"{API_ENDPOINT}/repo-groups/25155/aggregate-summary", timeout=10)
 try:
   if r.ok:
     print("OK!")


### PR DESCRIPTION
Identified that the Python build scripts performing external API requests were missing timeouts. By default, the `requests` library in Python waits indefinitely, which can cause CI/CD pipelines to hang and consume resources if a service is unresponsive. This PR adds reasonable timeout values (10s and 30s) to all network calls in `scripts/` to ensure they fail gracefully. Verified the changes by inspecting the files and running the existing build tools.

---
*PR created automatically by Jules for task [784334299594309462](https://jules.google.com/task/784334299594309462) started by @swainechen*