### PR TITLE
🛡️ Sentinel: Harden CSP and template security

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,20 +2,6 @@
 layout: default
 ---
 
-<!-- <style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style> -->
-
 <div class="section">
   <div class="container">
   <h1 class="small-title medium-margin">404</h1>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
     <!-- img-src 'self' data: https: restricts image sources to trusted origins and enforces secure transport. -->
     <!-- connect-src 'self' restricts the URLs which can be loaded using script interfaces. -->
     <!-- form-action 'none' prevents unauthorized form submissions as the site contains no forms. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests; object-src 'none'; base-uri 'none'; form-action 'none'; img-src 'self' data: https://www.straitstimes.com https://www.scotsman.com https://www.channelnewsasia.com https://www.asianscientist.com https://www.opengovasia.com https://www.tandfonline.com https://*.twimg.com https://platform.twitter.com; connect-src 'self' https://*.twitter.com https://syndication.twitter.com; script-src 'self' https://platform.twitter.com; style-src 'self' 'unsafe-inline'; frame-src https://www.youtube.com https://www.mewatch.sg https://platform.twitter.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests; object-src 'none'; base-uri 'none'; form-action 'none'; img-src 'self' data: https://www.straitstimes.com https://www.scotsman.com https://www.channelnewsasia.com https://www.asianscientist.com https://www.opengovasia.com https://www.tandfonline.com https://*.twimg.com https://platform.twitter.com; connect-src 'self' https://*.twitter.com https://syndication.twitter.com; script-src 'self' https://platform.twitter.com; style-src 'self'; frame-src https://www.youtube.com https://www.mewatch.sg https://platform.twitter.com;">
 
     <!-- Referrer Policy: strict-origin-when-cross-origin protects user privacy and prevents leaking sensitive information in Referer headers. -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
@@ -41,7 +41,7 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css"/>
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/{{ page.custom_css }}"/>
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/{{ page.custom_css | escape }}"/>
 
   </head>
 
@@ -146,7 +146,7 @@
     </div> <!-- End of Footer -->
     <script src="{{ site.baseurl }}/js/main.js"></script>
     <script src="{{ site.baseurl }}/js/responsive.js"></script>
-    <script src="{{ site.baseurl }}/js/{{ page.custom_js }}"></script>
+    <script src="{{ site.baseurl }}/js/{{ page.custom_js | escape }}"></script>
   </body>
 
 </html>


### PR DESCRIPTION
I have hardened the site's security by tightening the Content-Security-Policy and improving template escaping.

Key changes:
- Removed `'unsafe-inline'` from `style-src` in `_layouts/default.html`.
- Added `| escape` filters to `page.custom_js` and `page.custom_css` in the main layout.
- Removed dead style code from `404.html`.

Verification:
- Built the site with Jekyll and verified the generated HTML.
- Performed frontend verification using Playwright to ensure no regressions in layout or functionality.
- Confirmed that dynamic styling (via JavaScript) continues to work as expected under the stricter CSP.

---
*PR created automatically by Jules for task [12140681122216735514](https://jules.google.com/task/12140681122216735514) started by @swainechen*