### PR TITLE
🛡️ Sentinel: Tighten Content Security Policy img-src directive

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,10 +16,10 @@
 
     <!-- Security Enhancement: Automatically upgrade all insecure (HTTP) requests to secure (HTTPS) -->
     <!-- Content-Security-Policy includes upgrade-insecure-requests, object-src 'none' to prevent plugin-based attacks, and base-uri 'none' to restrict <base> tag. -->
-    <!-- img-src 'self' data: https: restricts image sources to trusted origins and enforces secure transport. -->
+    <!-- img-src 'self' restricts image sources to trusted origins and enforces secure transport. -->
     <!-- connect-src 'self' restricts the URLs which can be loaded using script interfaces. -->
     <!-- form-action 'none' prevents unauthorized form submissions as the site contains no forms. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests; object-src 'none'; base-uri 'none'; form-action 'none'; font-src 'self'; media-src 'none'; manifest-src 'self'; img-src 'self' data: https://www.straitstimes.com https://www.scotsman.com https://www.channelnewsasia.com https://www.asianscientist.com https://www.opengovasia.com https://www.tandfonline.com https://*.twimg.com https://platform.twitter.com; connect-src 'self' https://*.twitter.com https://syndication.twitter.com; script-src 'self' https://platform.twitter.com; style-src 'self'; frame-src https://www.youtube.com https://www.mewatch.sg https://platform.twitter.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests; object-src 'none'; base-uri 'none'; form-action 'none'; font-src 'self'; media-src 'none'; manifest-src 'self'; img-src 'self' https://www.straitstimes.com https://www.scotsman.com https://www.channelnewsasia.com https://www.asianscientist.com https://www.opengovasia.com https://www.tandfonline.com https://*.twimg.com https://platform.twitter.com; connect-src 'self' https://*.twitter.com https://syndication.twitter.com; script-src 'self' https://platform.twitter.com; style-src 'self'; frame-src https://www.youtube.com https://www.mewatch.sg https://platform.twitter.com;">
 
     <!-- Referrer Policy: strict-origin-when-cross-origin protects user privacy and prevents leaking sensitive information in Referer headers. -->
     <meta name="referrer" content="strict-origin-when-cross-origin">


### PR DESCRIPTION
This PR tightens the Content Security Policy (CSP) of the site by removing the 'data:' source from the 'img-src' directive. 

🚨 Severity: LOW (Security Enhancement)
💡 Vulnerability: Overly permissive CSP allowing 'data:' URIs for images.
🎯 Impact: While not directly exploitable in the current state of the repo, keeping unused sources in CSP increases the attack surface for potential XSS bypasses or data exfiltration via image-based side channels.
🔧 Fix: Removed 'data:' from 'img-src' in '_layouts/default.html' and updated the accompanying comment.
✅ Verification: Verified that the site still builds and renders correctly. Performed a grep search to confirm that 'data:image' or other 'data:' URIs are not used for images in the codebase.

---
*PR created automatically by Jules for task [15826002372414339931](https://jules.google.com/task/15826002372414339931) started by @swainechen*