### PR TITLE
🛡️ Sentinel: Harden YouTube embeds and tighten CSP

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,10 +19,11 @@
     <!-- img-src 'self' restricts image sources to trusted origins and enforces secure transport. -->
     <!-- connect-src 'self' restricts the URLs which can be loaded using script interfaces. -->
     <!-- form-action 'none' prevents unauthorized form submissions as the site contains no forms. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests; object-src 'none'; base-uri 'none'; form-action 'none'; font-src 'self'; media-src 'none'; manifest-src 'self'; img-src 'self' https://www.straitstimes.com https://www.scotsman.com https://www.channelnewsasia.com https://www.asianscientist.com https://www.tandfonline.com https://*.twimg.com https://platform.twitter.com; connect-src 'self' https://*.twitter.com https://syndication.twitter.com; script-src 'self' https://platform.twitter.com; style-src 'self'; frame-src https://www.youtube.com https://platform.twitter.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests; object-src 'none'; base-uri 'none'; form-action 'none'; font-src 'self'; media-src 'none'; manifest-src 'self'; img-src 'self' https://www.straitstimes.com https://www.scotsman.com https://www.channelnewsasia.com https://www.asianscientist.com https://www.tandfonline.com https://*.twimg.com https://platform.twitter.com; connect-src 'self' https://*.twitter.com https://syndication.twitter.com; script-src 'self' https://platform.twitter.com; style-src 'self'; frame-src https://www.youtube-nocookie.com https://platform.twitter.com;">
 
     <!-- Referrer Policy: strict-origin-when-cross-origin protects user privacy and prevents leaking sensitive information in Referer headers. -->
     <meta name="referrer" content="strict-origin-when-cross-origin">
+
 
     <meta http-equiv="Expires" content="0">
     <meta http-equiv="Pragma" content="no-cache">

--- a/publicity.html
+++ b/publicity.html
@@ -31,7 +31,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <div class="center-text mega-margin">
-            <iframe width="320" height="180" src="https://www.youtube.com/embed/v8IVMdOBs_0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+            <iframe width="320" height="180" src="https://www.youtube-nocookie.com/embed/v8IVMdOBs_0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
           <br>
             Episode of <i>Disease Hunters</i> on CNA, focused on bacteria and antibiotic resistance.<br>
             [ <a href="https://m.youtube.com/watch?feature=youtu.be&v=v8IVMdOBs_0" target="_blank" rel="noopener noreferrer">Trailer</a> ] [ <a href="https://www.channelnewsasia.com/news/video-on-demand/disease-hunters/disease-hunters-battle-against-bacteria-13622094" target="_blank" rel="noopener noreferrer">Full Episode</a> ] (2020)
@@ -64,7 +64,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <div class="center-text mega-margin">
-            <iframe width="320" height="180" src="https://www.youtube.com/embed/fDAHUow34_Q" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+            <iframe width="320" height="180" src="https://www.youtube-nocookie.com/embed/fDAHUow34_Q" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
           <br>
             <a href="https://www.asianscientist.com/2019/05/features/sea-beast-gbs-food-safety-aquaculture/" target="_blank" rel="noopener noreferrer">Op-Ed/Perspective</a> in <a href="https://www.asianscientist.com" target="_blank" rel="noopener noreferrer">Asian Scientist</a> on our GBS work throughout SEAsia, including <a href="https://youtu.be/fDAHUow34_Q" target="_blank" rel="noopener noreferrer">video</a>
           </div>
@@ -80,7 +80,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <div class="center-text mega-margin">
-            <iframe width="320" height="180" src="https://www.youtube.com/embed/yIJB8Deo-XU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+            <iframe width="320" height="180" src="https://www.youtube-nocookie.com/embed/yIJB8Deo-XU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
           <br>
             <a href="https://youtu.be/yIJB8Deo-XU" target="_blank" rel="noopener noreferrer">TEDx talk</a> - A genomic future is upon us (2018)
           </div>
@@ -88,7 +88,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <div class="center-text mega-margin">
-            <iframe width="320" height="180" src="https://www.youtube.com/embed/AmHCUy-_VPI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+            <iframe width="320" height="180" src="https://www.youtube-nocookie.com/embed/AmHCUy-_VPI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
           <br>
             <a href="https://www.seriouslyscience.sg/Knowledge/Videos/Genomics-Helping-to-Tackle-Infections-and-Beyond-in-a-Smart-Nation" target="_blank" rel="noopener noreferrer">Public talk</a> at the One North Festival (2018)
           </div>
@@ -96,7 +96,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <div class="center-text mega-margin">
-            <iframe width="320" height="180" src="https://www.youtube.com/embed/d5dOlbArKh0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+            <iframe width="320" height="180" src="https://www.youtube-nocookie.com/embed/d5dOlbArKh0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
           <br>
             <a href="https://youtu.be/d5dOlbArKh0" target="_blank" rel="noopener noreferrer">Keynote</a> at the AWS Public Sector Summit (2018)
           </div>
@@ -104,7 +104,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <div class="center-text mega-margin">
-            <iframe width="320" height="180" src="https://www.youtube.com/embed/pK8JcT3F0jU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+            <iframe width="320" height="180" src="https://www.youtube-nocookie.com/embed/pK8JcT3F0jU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
           <br>
             <a href="https://youtu.be/pK8JcT3F0jU" target="_blank" rel="noopener noreferrer">Interview</a> with SiliconEdge<br>on the sidelines of the AWS Public Sector Summit (2018)
           </div>
@@ -120,7 +120,7 @@ custom_js: publicity.js
 
         <div class="Grid-cell img-card u-size1of3">
           <div class="center-text mega-margin">
-            <iframe width="320" height="180" src="https://www.youtube.com/embed/yEtx0Aknke8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
+            <iframe width="320" height="180" src="https://www.youtube-nocookie.com/embed/yEtx0Aknke8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" referrerpolicy="strict-origin-when-cross-origin"></iframe>
           <br>
             CNA <a href="https://youtu.be/yEtx0Aknke8" target="_blank" rel="noopener noreferrer">video</a> and <a href="https://www.channelnewsasia.com/news/cnainsider/how-dirty-money-bacteria-banknotes-singapore-9503352" target="_blank" rel="noopener noreferrer">article</a> on bacteria on bank notes (2017)
           </div>


### PR DESCRIPTION
I have hardened the application's privacy posture by migrating all YouTube embeds to their privacy-enhanced "nocookie" version and tightening the site-wide Content Security Policy (CSP).

### 🚨 Severity: MEDIUM (Privacy Enhancement & Defense-in-Depth)

### 💡 Vulnerability: User Tracking & Overly Permissive CSP
The site previously used standard YouTube embeds which could set tracking cookies even before user interaction. Additionally, the CSP allowed the broad `https://www.youtube.com` origin in the `frame-src` directive.

### 🎯 Impact
Using privacy-enhanced embeds protects user privacy by limiting cross-site tracking. Tightening the CSP follows the principle of least privilege, reducing the attack surface for unauthorized frame injection.

### 🔧 Fix
1.  **Harden YouTube iframes**: Updated all 7 video embeds in `publicity.html` to use `https://www.youtube-nocookie.com/embed/`.
2.  **Tighten CSP**: Updated the `frame-src` directive in `_layouts/default.html` to allow `https://www.youtube-nocookie.com` and remove `https://www.youtube.com`.

### ✅ Verification
- **Source Verification**: Confirmed all URLs were correctly updated in `publicity.html` and `_layouts/default.html`.
- **Build Verification**: Ran `bundle exec jekyll build` to ensure the site generates correctly.
- **Frontend Verification**: Used Playwright to verify that the generated `_site/publicity.html` correctly renders all iframes with the privacy-enhanced domain. Recorded a video of the verification process.

---
*PR created automatically by Jules for task [5235860102237426800](https://jules.google.com/task/5235860102237426800) started by @swainechen*