### PR TITLE
🛡️ Sentinel: Harden CSP with worker-src 'none'

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
     <!-- img-src 'self' restricts image sources to trusted origins and enforces secure transport. -->
     <!-- connect-src 'self' restricts the URLs which can be loaded using script interfaces. -->
     <!-- form-action 'none' prevents unauthorized form submissions as the site contains no forms. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests; object-src 'none'; base-uri 'none'; form-action 'none'; font-src 'self'; media-src 'none'; manifest-src 'self'; img-src 'self' https://*.twimg.com https://platform.twitter.com; connect-src 'self' https://*.twitter.com https://syndication.twitter.com; script-src 'self' https://platform.twitter.com; script-src-attr 'none'; style-src 'self'; style-src-attr 'none'; frame-src https://www.youtube-nocookie.com https://platform.twitter.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; upgrade-insecure-requests; object-src 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'; font-src 'self'; media-src 'none'; manifest-src 'self'; img-src 'self' https://*.twimg.com https://platform.twitter.com; connect-src 'self' https://*.twitter.com https://syndication.twitter.com; script-src 'self' https://platform.twitter.com; script-src-attr 'none'; style-src 'self'; style-src-attr 'none'; frame-src https://www.youtube-nocookie.com https://platform.twitter.com;">
 
     <!-- Referrer Policy: strict-origin-when-cross-origin protects user privacy and prevents leaking sensitive information in Referer headers. -->
     <meta name="referrer" content="strict-origin-when-cross-origin">


### PR DESCRIPTION
Added worker-src 'none' to the site-wide Content Security Policy in _layouts/default.html. This provides defense-in-depth by explicitly disabling Web Workers, Shared Workers, and Service Workers, which reduces the attack surface for potential background script-based attacks or data exfiltration.

---
*PR created automatically by Jules for task [279649887605262355](https://jules.google.com/task/279649887605262355) started by @swainechen*